### PR TITLE
Rpi3 and rpi4

### DIFF
--- a/src/rpi3/pi_2_dht_read.c
+++ b/src/rpi3/pi_2_dht_read.c
@@ -1,0 +1,158 @@
+// Copyright (c) 2014 Adafruit Industries
+// Author: Tony DiCola
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "pi_2_dht_read.h"
+#include "pi_2_mmio.h"
+
+// This is the only processor specific magic value, the maximum amount of time to
+// spin in a loop before bailing out and considering the read a timeout.  This should
+// be a high value, but if you're running on a much faster platform than a Raspberry
+// Pi or Beaglebone Black then it might need to be increased.
+#define DHT_MAXCOUNT 32000
+
+// Number of bit pulses to expect from the DHT.  Note that this is 41 because
+// the first pulse is a constant 50 microsecond pulse, with 40 pulses to represent
+// the data afterwards.
+#define DHT_PULSES 41
+
+int pi_2_dht_read(int type, int pin, float* humidity, float* temperature) {
+  // Validate humidity and temperature arguments and set them to zero.
+  if (humidity == NULL || temperature == NULL) {
+    return DHT_ERROR_ARGUMENT;
+  }
+  *temperature = 0.0f;
+  *humidity = 0.0f;
+
+  // Initialize GPIO library.
+  if (pi_2_mmio_init() < 0) {
+    return DHT_ERROR_GPIO;
+  }
+
+  // Store the count that each DHT bit pulse is low and high.
+  // Make sure array is initialized to start at zero.
+  int pulseCounts[DHT_PULSES*2] = {0};
+
+  // Set pin to output.
+  pi_2_mmio_set_output(pin);
+
+  // Bump up process priority and change scheduler to try to try to make process more 'real time'.
+  set_max_priority();
+
+  // Set pin high for ~500 milliseconds.
+  pi_2_mmio_set_high(pin);
+  sleep_milliseconds(500);
+
+  // The next calls are timing critical and care should be taken
+  // to ensure no unnecssary work is done below.
+
+  // Set pin low for ~20 milliseconds.
+  pi_2_mmio_set_low(pin);
+  busy_wait_milliseconds(20);
+
+  // Set pin at input.
+  pi_2_mmio_set_input(pin);
+  // Need a very short delay before reading pins or else value is sometimes still low.
+  for (volatile int i = 0; i < 50; ++i) {
+  }
+
+  // Wait for DHT to pull pin low.
+  uint32_t count = 0;
+  while (pi_2_mmio_input(pin)) {
+    if (++count >= DHT_MAXCOUNT) {
+      // Timeout waiting for response.
+      set_default_priority();
+      return DHT_ERROR_TIMEOUT;
+    }
+  }
+
+  // Record pulse widths for the expected result bits.
+  for (int i=0; i < DHT_PULSES*2; i+=2) {
+    // Count how long pin is low and store in pulseCounts[i]
+    while (!pi_2_mmio_input(pin)) {
+      if (++pulseCounts[i] >= DHT_MAXCOUNT) {
+        // Timeout waiting for response.
+        set_default_priority();
+        return DHT_ERROR_TIMEOUT;
+      }
+    }
+    // Count how long pin is high and store in pulseCounts[i+1]
+    while (pi_2_mmio_input(pin)) {
+      if (++pulseCounts[i+1] >= DHT_MAXCOUNT) {
+        // Timeout waiting for response.
+        set_default_priority();
+        return DHT_ERROR_TIMEOUT;
+      }
+    }
+  }
+
+  // Done with timing critical code, now interpret the results.
+
+  // Drop back to normal priority.
+  set_default_priority();
+
+  // Compute the average low pulse width to use as a 50 microsecond reference threshold.
+  // Ignore the first two readings because they are a constant 80 microsecond pulse.
+  uint32_t threshold = 0;
+  for (int i=2; i < DHT_PULSES*2; i+=2) {
+    threshold += pulseCounts[i];
+  }
+  threshold /= DHT_PULSES-1;
+
+  // Interpret each high pulse as a 0 or 1 by comparing it to the 50us reference.
+  // If the count is less than 50us it must be a ~28us 0 pulse, and if it's higher
+  // then it must be a ~70us 1 pulse.
+  uint8_t data[5] = {0};
+  for (int i=3; i < DHT_PULSES*2; i+=2) {
+    int index = (i-3)/16;
+    data[index] <<= 1;
+    if (pulseCounts[i] >= threshold) {
+      // One bit for long pulse.
+      data[index] |= 1;
+    }
+    // Else zero bit for short pulse.
+  }
+
+  // Useful debug info:
+  //printf("Data: 0x%x 0x%x 0x%x 0x%x 0x%x\n", data[0], data[1], data[2], data[3], data[4]);
+
+  // Verify checksum of received data.
+  if (data[4] == ((data[0] + data[1] + data[2] + data[3]) & 0xFF)) {
+    if (type == DHT11) {
+      // Get humidity and temp for DHT11 sensor.
+      *humidity = (float)data[0];
+      *temperature = (float)data[2];
+    }
+    else if (type == DHT22) {
+      // Calculate humidity and temp for DHT22 sensor.
+      *humidity = (data[0] * 256 + data[1]) / 10.0f;
+      *temperature = ((data[2] & 0x7F) * 256 + data[3]) / 10.0f;
+      if (data[2] & 0x80) {
+        *temperature *= -1.0f;
+      }
+    }
+    return DHT_SUCCESS;
+  }
+  else {
+    return DHT_ERROR_CHECKSUM;
+  }
+}

--- a/src/rpi3/pi_2_dht_read.h
+++ b/src/rpi3/pi_2_dht_read.h
@@ -1,0 +1,32 @@
+// Copyright (c) 2014 Adafruit Industries
+// Author: Tony DiCola
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#ifndef PI_2_DHT_READ_H
+#define PI_2_DHT_READ_H
+
+#include "../common_dht_read.h"
+
+// Read DHT sensor connected to GPIO pin (using BCM numbering).  Humidity and temperature will be 
+// returned in the provided parameters. If a successfull reading could be made a value of 0 
+// (DHT_SUCCESS) will be returned.  If there was an error reading the sensor a negative value will
+// be returned.  Some errors can be ignored and retried, specifically DHT_ERROR_TIMEOUT or DHT_ERROR_CHECKSUM.
+int pi_2_dht_read(int sensor, int pin, float* humidity, float* temperature);
+
+#endif

--- a/src/rpi3/pi_2_mmio.c
+++ b/src/rpi3/pi_2_mmio.c
@@ -1,0 +1,71 @@
+// Copyright (c) 2014 Adafruit Industries
+// Author: Tony DiCola
+// Based on code from Gert van Loo & Dom: http://elinux.org/RPi_Low-level_peripherals#GPIO_Code_examples
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#include <fcntl.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "pi_2_mmio.h"
+
+#define GPIO_BASE_OFFSET 0x200000
+#define GPIO_LENGTH 4096
+
+volatile uint32_t* pi_2_mmio_gpio = NULL;
+
+int pi_2_mmio_init(void) {
+  if (pi_2_mmio_gpio == NULL) {
+    // Check for GPIO and peripheral addresses from device tree.
+    // Adapted from code in the RPi.GPIO library at:
+    //   http://sourceforge.net/p/raspberry-gpio-python/
+    FILE *fp = fopen("/proc/device-tree/soc/ranges", "rb");
+    if (fp == NULL) {
+      return MMIO_ERROR_OFFSET;
+    }
+    fseek(fp, 4, SEEK_SET);
+    unsigned char buf[4];
+    if (fread(buf, 1, sizeof(buf), fp) != sizeof(buf)) {
+      return MMIO_ERROR_OFFSET;
+    }
+    uint32_t peri_base = buf[0] << 24 | buf[1] << 16 | buf[2] << 8 | buf[3] << 0;
+    uint32_t gpio_base = peri_base + GPIO_BASE_OFFSET;
+    fclose(fp);
+
+    int fd = open("/dev/gpiomem", O_RDWR | O_SYNC);
+    if (fd == -1) {
+      // Error opening /dev/gpiomem.
+      return MMIO_ERROR_DEVMEM;
+    }
+    // Map GPIO memory to location in process space.
+    pi_2_mmio_gpio = (uint32_t*)mmap(NULL, GPIO_LENGTH, PROT_READ | PROT_WRITE, MAP_SHARED, fd, gpio_base);
+    close(fd);
+    if (pi_2_mmio_gpio == MAP_FAILED) {
+      // Don't save the result if the memory mapping failed.
+      pi_2_mmio_gpio = NULL;
+      return MMIO_ERROR_MMAP;
+    }
+  }
+  return MMIO_SUCCESS;
+}

--- a/src/rpi3/pi_2_mmio.h
+++ b/src/rpi3/pi_2_mmio.h
@@ -1,0 +1,62 @@
+// Copyright (c) 2014 Adafruit Industries
+// Author: Tony DiCola
+// Based on code from Gert van Loo & Dom: http://elinux.org/RPi_Low-level_peripherals#GPIO_Code_examples
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Simple fast memory-mapped GPIO library for the Raspberry Pi.
+#ifndef PI_2_MMIO_H
+#define PI_2_MMIO_H
+
+#include <stdint.h>
+
+#define MMIO_SUCCESS 0
+#define MMIO_ERROR_DEVMEM -1
+#define MMIO_ERROR_MMAP -2
+#define MMIO_ERROR_OFFSET -3
+
+extern volatile uint32_t* pi_2_mmio_gpio;
+
+int pi_2_mmio_init(void);
+
+static inline void pi_2_mmio_set_input(const int gpio_number) {
+  // Set GPIO register to 000 for specified GPIO number.
+  *(pi_2_mmio_gpio+((gpio_number)/10)) &= ~(7<<(((gpio_number)%10)*3));
+}
+
+static inline void pi_2_mmio_set_output(const int gpio_number) {
+  // First set to 000 using input function.
+  pi_2_mmio_set_input(gpio_number);
+  // Next set bit 0 to 1 to set output.
+  *(pi_2_mmio_gpio+((gpio_number)/10)) |=  (1<<(((gpio_number)%10)*3));
+}
+
+static inline void pi_2_mmio_set_high(const int gpio_number) {
+  *(pi_2_mmio_gpio+7) = 1 << gpio_number;
+}
+
+static inline void pi_2_mmio_set_low(const int gpio_number) {
+  *(pi_2_mmio_gpio+10) = 1 << gpio_number;
+}
+
+static inline uint32_t pi_2_mmio_input(const int gpio_number) {
+  return *(pi_2_mmio_gpio+13) & (1 << gpio_number);
+}
+
+#endif

--- a/src/rpi4/pi_2_dht_read.c
+++ b/src/rpi4/pi_2_dht_read.c
@@ -1,0 +1,158 @@
+// Copyright (c) 2014 Adafruit Industries
+// Author: Tony DiCola
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "pi_2_dht_read.h"
+#include "pi_2_mmio.h"
+
+// This is the only processor specific magic value, the maximum amount of time to
+// spin in a loop before bailing out and considering the read a timeout.  This should
+// be a high value, but if you're running on a much faster platform than a Raspberry
+// Pi or Beaglebone Black then it might need to be increased.
+#define DHT_MAXCOUNT 32000
+
+// Number of bit pulses to expect from the DHT.  Note that this is 41 because
+// the first pulse is a constant 50 microsecond pulse, with 40 pulses to represent
+// the data afterwards.
+#define DHT_PULSES 41
+
+int pi_2_dht_read(int type, int pin, float* humidity, float* temperature) {
+  // Validate humidity and temperature arguments and set them to zero.
+  if (humidity == NULL || temperature == NULL) {
+    return DHT_ERROR_ARGUMENT;
+  }
+  *temperature = 0.0f;
+  *humidity = 0.0f;
+
+  // Initialize GPIO library.
+  if (pi_2_mmio_init() < 0) {
+    return DHT_ERROR_GPIO;
+  }
+
+  // Store the count that each DHT bit pulse is low and high.
+  // Make sure array is initialized to start at zero.
+  int pulseCounts[DHT_PULSES*2] = {0};
+
+  // Set pin to output.
+  pi_2_mmio_set_output(pin);
+
+  // Bump up process priority and change scheduler to try to try to make process more 'real time'.
+  set_max_priority();
+
+  // Set pin high for ~500 milliseconds.
+  pi_2_mmio_set_high(pin);
+  sleep_milliseconds(500);
+
+  // The next calls are timing critical and care should be taken
+  // to ensure no unnecssary work is done below.
+
+  // Set pin low for ~20 milliseconds.
+  pi_2_mmio_set_low(pin);
+  busy_wait_milliseconds(20);
+
+  // Set pin at input.
+  pi_2_mmio_set_input(pin);
+  // Need a very short delay before reading pins or else value is sometimes still low.
+  for (volatile int i = 0; i < 50; ++i) {
+  }
+
+  // Wait for DHT to pull pin low.
+  uint32_t count = 0;
+  while (pi_2_mmio_input(pin)) {
+    if (++count >= DHT_MAXCOUNT) {
+      // Timeout waiting for response.
+      set_default_priority();
+      return DHT_ERROR_TIMEOUT;
+    }
+  }
+
+  // Record pulse widths for the expected result bits.
+  for (int i=0; i < DHT_PULSES*2; i+=2) {
+    // Count how long pin is low and store in pulseCounts[i]
+    while (!pi_2_mmio_input(pin)) {
+      if (++pulseCounts[i] >= DHT_MAXCOUNT) {
+        // Timeout waiting for response.
+        set_default_priority();
+        return DHT_ERROR_TIMEOUT;
+      }
+    }
+    // Count how long pin is high and store in pulseCounts[i+1]
+    while (pi_2_mmio_input(pin)) {
+      if (++pulseCounts[i+1] >= DHT_MAXCOUNT) {
+        // Timeout waiting for response.
+        set_default_priority();
+        return DHT_ERROR_TIMEOUT;
+      }
+    }
+  }
+
+  // Done with timing critical code, now interpret the results.
+
+  // Drop back to normal priority.
+  set_default_priority();
+
+  // Compute the average low pulse width to use as a 50 microsecond reference threshold.
+  // Ignore the first two readings because they are a constant 80 microsecond pulse.
+  uint32_t threshold = 0;
+  for (int i=2; i < DHT_PULSES*2; i+=2) {
+    threshold += pulseCounts[i];
+  }
+  threshold /= DHT_PULSES-1;
+
+  // Interpret each high pulse as a 0 or 1 by comparing it to the 50us reference.
+  // If the count is less than 50us it must be a ~28us 0 pulse, and if it's higher
+  // then it must be a ~70us 1 pulse.
+  uint8_t data[5] = {0};
+  for (int i=3; i < DHT_PULSES*2; i+=2) {
+    int index = (i-3)/16;
+    data[index] <<= 1;
+    if (pulseCounts[i] >= threshold) {
+      // One bit for long pulse.
+      data[index] |= 1;
+    }
+    // Else zero bit for short pulse.
+  }
+
+  // Useful debug info:
+  //printf("Data: 0x%x 0x%x 0x%x 0x%x 0x%x\n", data[0], data[1], data[2], data[3], data[4]);
+
+  // Verify checksum of received data.
+  if (data[4] == ((data[0] + data[1] + data[2] + data[3]) & 0xFF)) {
+    if (type == DHT11) {
+      // Get humidity and temp for DHT11 sensor.
+      *humidity = (float)data[0];
+      *temperature = (float)data[2];
+    }
+    else if (type == DHT22) {
+      // Calculate humidity and temp for DHT22 sensor.
+      *humidity = (data[0] * 256 + data[1]) / 10.0f;
+      *temperature = ((data[2] & 0x7F) * 256 + data[3]) / 10.0f;
+      if (data[2] & 0x80) {
+        *temperature *= -1.0f;
+      }
+    }
+    return DHT_SUCCESS;
+  }
+  else {
+    return DHT_ERROR_CHECKSUM;
+  }
+}

--- a/src/rpi4/pi_2_dht_read.h
+++ b/src/rpi4/pi_2_dht_read.h
@@ -1,0 +1,32 @@
+// Copyright (c) 2014 Adafruit Industries
+// Author: Tony DiCola
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#ifndef PI_2_DHT_READ_H
+#define PI_2_DHT_READ_H
+
+#include "../common_dht_read.h"
+
+// Read DHT sensor connected to GPIO pin (using BCM numbering).  Humidity and temperature will be 
+// returned in the provided parameters. If a successfull reading could be made a value of 0 
+// (DHT_SUCCESS) will be returned.  If there was an error reading the sensor a negative value will
+// be returned.  Some errors can be ignored and retried, specifically DHT_ERROR_TIMEOUT or DHT_ERROR_CHECKSUM.
+int pi_2_dht_read(int sensor, int pin, float* humidity, float* temperature);
+
+#endif

--- a/src/rpi4/pi_2_mmio.c
+++ b/src/rpi4/pi_2_mmio.c
@@ -1,0 +1,71 @@
+// Copyright (c) 2014 Adafruit Industries
+// Author: Tony DiCola
+// Based on code from Gert van Loo & Dom: http://elinux.org/RPi_Low-level_peripherals#GPIO_Code_examples
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#include <fcntl.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "pi_2_mmio.h"
+
+#define GPIO_BASE_OFFSET 0x200000
+#define GPIO_LENGTH 4096
+
+volatile uint32_t* pi_2_mmio_gpio = NULL;
+
+int pi_2_mmio_init(void) {
+  if (pi_2_mmio_gpio == NULL) {
+    // Check for GPIO and peripheral addresses from device tree.
+    // Adapted from code in the RPi.GPIO library at:
+    //   http://sourceforge.net/p/raspberry-gpio-python/
+    FILE *fp = fopen("/proc/device-tree/soc/ranges", "rb");
+    if (fp == NULL) {
+      return MMIO_ERROR_OFFSET;
+    }
+    fseek(fp, 4, SEEK_SET);
+    unsigned char buf[4];
+    if (fread(buf, 1, sizeof(buf), fp) != sizeof(buf)) {
+      return MMIO_ERROR_OFFSET;
+    }
+    uint32_t peri_base = buf[0] << 24 | buf[1] << 16 | buf[2] << 8 | buf[3] << 0;
+    uint32_t gpio_base = peri_base + GPIO_BASE_OFFSET;
+    fclose(fp);
+
+    int fd = open("/dev/gpiomem", O_RDWR | O_SYNC);
+    if (fd == -1) {
+      // Error opening /dev/gpiomem.
+      return MMIO_ERROR_DEVMEM;
+    }
+    // Map GPIO memory to location in process space.
+    pi_2_mmio_gpio = (uint32_t*)mmap(NULL, GPIO_LENGTH, PROT_READ | PROT_WRITE, MAP_SHARED, fd, gpio_base);
+    close(fd);
+    if (pi_2_mmio_gpio == MAP_FAILED) {
+      // Don't save the result if the memory mapping failed.
+      pi_2_mmio_gpio = NULL;
+      return MMIO_ERROR_MMAP;
+    }
+  }
+  return MMIO_SUCCESS;
+}

--- a/src/rpi4/pi_2_mmio.h
+++ b/src/rpi4/pi_2_mmio.h
@@ -1,0 +1,62 @@
+// Copyright (c) 2014 Adafruit Industries
+// Author: Tony DiCola
+// Based on code from Gert van Loo & Dom: http://elinux.org/RPi_Low-level_peripherals#GPIO_Code_examples
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Simple fast memory-mapped GPIO library for the Raspberry Pi.
+#ifndef PI_2_MMIO_H
+#define PI_2_MMIO_H
+
+#include <stdint.h>
+
+#define MMIO_SUCCESS 0
+#define MMIO_ERROR_DEVMEM -1
+#define MMIO_ERROR_MMAP -2
+#define MMIO_ERROR_OFFSET -3
+
+extern volatile uint32_t* pi_2_mmio_gpio;
+
+int pi_2_mmio_init(void);
+
+static inline void pi_2_mmio_set_input(const int gpio_number) {
+  // Set GPIO register to 000 for specified GPIO number.
+  *(pi_2_mmio_gpio+((gpio_number)/10)) &= ~(7<<(((gpio_number)%10)*3));
+}
+
+static inline void pi_2_mmio_set_output(const int gpio_number) {
+  // First set to 000 using input function.
+  pi_2_mmio_set_input(gpio_number);
+  // Next set bit 0 to 1 to set output.
+  *(pi_2_mmio_gpio+((gpio_number)/10)) |=  (1<<(((gpio_number)%10)*3));
+}
+
+static inline void pi_2_mmio_set_high(const int gpio_number) {
+  *(pi_2_mmio_gpio+7) = 1 << gpio_number;
+}
+
+static inline void pi_2_mmio_set_low(const int gpio_number) {
+  *(pi_2_mmio_gpio+10) = 1 << gpio_number;
+}
+
+static inline uint32_t pi_2_mmio_input(const int gpio_number) {
+  return *(pi_2_mmio_gpio+13) & (1 << gpio_number);
+}
+
+#endif


### PR DESCRIPTION
I needed to run this drivers to the rpi3 target, at the Adafruit_Python_DHT, they [use the same driver for rpi3](https://github.com/adafruit/Adafruit_Python_DHT/commit/e1d10e1513c4fff55733f3926c0e3665f407ffc8#diff-866b612c194e04267a330fa469e9049f), [and for rpi 4](https://github.com/adafruit/Adafruit_Python_DHT/commit/f2799f8408a4d3d105d9457fd9222a942bf57394#diff-866b612c194e04267a330fa469e9049f)

This PR adds drivers for rpi3 and rpi4 targets.